### PR TITLE
fix: allow for two files with same basename and stop poluting /tmp

### DIFF
--- a/lib/YAML/Diff/Command.pm
+++ b/lib/YAML/Diff/Command.pm
@@ -3,8 +3,8 @@ use Mo;
 
 has args => ();
 
+use File::Temp;
 use YAML::XS;
-use IO::All;
 
 sub run {
     my ($self) = @_;
@@ -17,17 +17,16 @@ sub run {
     my $yaml1 = YAML::XS::Dump(YAML::XS::LoadFile($file1));
     my $yaml2 = YAML::XS::Dump(YAML::XS::LoadFile($file2));
 
-    (my $tmp1 = $file1) =~ s!.*/!!;
-    (my $tmp2 = $file2) =~ s!.*/!!;
-    $tmp1 = "/tmp/$tmp1";
-    $tmp2 = "/tmp/$tmp2";
-
     if ($yaml1 eq $yaml2) {
         print "Matched\n";
     }
     else {
-        io($tmp1)->print($yaml1);
-        io($tmp2)->print($yaml2);
+        (my $tmp1 = $file1) =~ s!.*/!!;
+        (my $tmp2 = $file2) =~ s!.*/!!;
+        $tmp1 = File::Temp->new( TEMPLATE => "${tmp1}_XXXXX" );
+        $tmp2 = File::Temp->new( TEMPLATE => "${tmp2}_XXXXX" );
+        $tmp1->print( $yaml1 );
+        $tmp2->print( $yaml2 );
         system "diff -u $tmp1 $tmp2";
     }
 }


### PR DESCRIPTION
nice and useful command, but fails to diff to files with same basename:

`perl -e 'mkdir("dir"); open(X,">dir/a"); print X "---\nfoo: 1\n"; open(X,">a"); print X "---\nbar: 1\n";'`

and leaves files in /tmp :-(

